### PR TITLE
Set noisy build messages to debug level

### DIFF
--- a/src/build/buildSource.ts
+++ b/src/build/buildSource.ts
@@ -17,7 +17,7 @@ export const buildSource = async (
 	dev: boolean,
 	log: Logger,
 ): Promise<void> => {
-	log.info('building source', gray(dev ? 'development' : 'production'));
+	log.debug('building source', gray(dev ? 'development' : 'production'));
 
 	await sveltekitSync(fs);
 
@@ -25,11 +25,11 @@ export const buildSource = async (
 	const timings = new Timings();
 	const logTimings = () => {
 		printTimings(timings, log);
-		log.info(`🕒 built in ${printMs(totalTiming())}`);
+		log.debug(`🕒 built in ${printMs(totalTiming())}`);
 	};
 
 	if (config.builds.some((b) => b.types)) {
-		log.info('building types');
+		log.debug('building types');
 		// Build all types so they're available.
 		// TODO refactor? maybe lazily build types only when a builder wants them
 		const timingToTypes = timings.start('types');
@@ -37,7 +37,7 @@ export const buildSource = async (
 		timingToTypes();
 	}
 
-	log.info('building files');
+	log.debug('building files');
 	const timingToCreateFiler = timings.start('create filer');
 	const filer = new Filer({
 		fs,

--- a/src/task/invokeTask.ts
+++ b/src/task/invokeTask.ts
@@ -91,7 +91,7 @@ export const invokeTask = async (
 
 			// Import these lazily to avoid importing their comparatively heavy transitive dependencies
 			// every time a task is invoked.
-			log.info('building project to run task');
+			log.debug('building project to run task');
 			const timingToLoadConfig = timings.start('load config');
 			// TODO probably do this as a separate process
 			// also this is messy, the `loadConfig` does some hacky config loading,


### PR DESCRIPTION
Sorry, I know this PR is coming from left field, but I was messing around with other deployment work & finally got annoyed enough to wade into `gro` 😅 

It downgrades a few log entries from `info` into `debug` around the core `buildSource`, since I was finding them kind of noisy as part of our build & deploy pipeline upstream in Felt.

I'm open to other avenues if you think semantically these lines should still be at the `info` level. I could take another pass but this time with a `verbose` or `suppress` CLI arg for hiding them instead if you'd prefer?

lmk what you think! Also the README docs worked great for local development! 🎉 